### PR TITLE
Added acts_as_indexed dependency for testing

### DIFF
--- a/lib/refinery/settings.rb
+++ b/lib/refinery/settings.rb
@@ -1,4 +1,5 @@
 require 'refinerycms-core'
+require 'acts_as_indexed'
 
 module Refinery
   autoload :SettingsGenerator, 'generators/refinery/settings_generator'

--- a/refinerycms-settings.gemspec
+++ b/refinerycms-settings.gemspec
@@ -17,4 +17,5 @@ Gem::Specification.new do |s|
   s.test_files        = `git ls-files -- spec/*`.split("\n")
 
   s.add_dependency 'refinerycms-core', '~> 2.1.0.dev'
+  s.add_dependency 'acts_as_indexed',  '~> 0.7.7'
 end


### PR DESCRIPTION
acts_as_indexed in the Gemfile is required to test a fresh checkout.
In the gemspec is required to test fresh checkouts that depend on this.
