### PR TITLE
fix dependency inconsistency with refinerycms 

### DIFF
--- a/refinerycms-settings.gemspec
+++ b/refinerycms-settings.gemspec
@@ -17,5 +17,5 @@ Gem::Specification.new do |s|
   s.test_files        = `git ls-files -- spec/*`.split("\n")
 
   s.add_dependency 'refinerycms-core', '~> 2.1.0.dev'
-  s.add_dependency 'acts_as_indexed',  '~> 0.7.7'
+  s.add_dependency 'acts_as_indexed',  '~> 0.8.1'
 end


### PR DESCRIPTION
fix this:

```
Bundler could not find compatible versions for gem "acts_as_indexed":
  In Gemfile:
    refinerycms-settings (>= 0) ruby depends on
      acts_as_indexed (~> 0.7.7) ruby

    refinerycms (>= 0) ruby depends on
      acts_as_indexed (0.8.1
```
