### PR TITLE
Don't lock therubyracer to 0.9 version.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,7 @@ group :development, :test do
       if RbConfig::CONFIG['target_os'] =~ /linux/i
         gem 'rb-inotify', '>= 0.5.1'
         gem 'libnotify',  '~> 0.1.3'
-        gem 'therubyracer', '~> 0.9.9'
+        gem 'therubyracer', '>= 0.9.9'
       end
     end
   end


### PR DESCRIPTION
@parndt any idea why it's locked? I can't compile for example any `therubyracer ~> 0.9.9`.
