### PR TITLE
Pull in aa380d6 "Let the model require acts_as_indexed" from master

### DIFF
--- a/app/models/refinery/setting.rb
+++ b/app/models/refinery/setting.rb
@@ -1,3 +1,5 @@
+require 'acts_as_indexed'
+
 module Refinery
   class Setting < Refinery::Core::BaseModel
     extend FriendlyId
@@ -25,7 +27,7 @@ module Refinery
     after_save do |setting|
       setting.class.rewrite_cache
     end
-    
+
     after_destroy do |setting|
       setting.class.rewrite_cache
     end

--- a/lib/refinery/settings.rb
+++ b/lib/refinery/settings.rb
@@ -1,5 +1,4 @@
 require 'refinerycms-core'
-require 'acts_as_indexed'
 
 module Refinery
   autoload :SettingsGenerator, 'generators/refinery/settings_generator'


### PR DESCRIPTION
This fixes `rake assets:precompile` to operate without having to load ActiveRecord.  More specifically, this is a fix for the Heroku Cedar platform where the database is not available during asset precompilation https://devcenter.heroku.com/articles/rails-asset-pipeline#troubleshooting
