### PR TITLE
Fixed new FriendlyId behavior for version 5 on rails 4

### DIFF
--- a/app/models/refinery/setting.rb
+++ b/app/models/refinery/setting.rb
@@ -1,7 +1,7 @@
 module Refinery
   class Setting < Refinery::Core::BaseModel
     extend FriendlyId
-    friendly_id :name, use: :slugged
+    friendly_id :name, use: [:slugged, :finders]
 
     FORM_VALUE_TYPES = [
       ['Multi-line', 'text_area'],


### PR DESCRIPTION
Hi,

i've fixed a new behavior for FriendlyId. On the new version the default finder replacement have been dropped. To get it back again you've got to add the finders addon like i've done it in my code. I hope it will get merged soon.

Cheers,
  Thomas
