### PR TITLE
Use rails 4 strong parameters to be compatible with refinery edge (3.0)

### DIFF
--- a/app/controllers/refinery/admin/settings_controller.rb
+++ b/app/controllers/refinery/admin/settings_controller.rb
@@ -50,6 +50,12 @@ module ::Refinery
       def sanitise_params
         params.delete(:scoping)
       end
+
+      def setting_params
+        params.require(:setting).permit(:title, :name, :value, :destroyable,
+                                          :scoping, :restricted, :form_value_type)
+      end
+
     end
   end
 end

--- a/app/models/refinery/setting.rb
+++ b/app/models/refinery/setting.rb
@@ -12,9 +12,6 @@ module Refinery
 
     serialize :value # stores into YAML format
 
-    attr_accessible :title, :name, :value, :destroyable,
-                    :scoping, :restricted, :form_value_type
-
     before_save do |setting|
       setting.restricted = false if setting.restricted.nil?
     end


### PR DESCRIPTION
The refinery edge now is incompatible with attr_accessible as of `4729b139452dd3a825b827e90fc96ee9936c37d3`.

This patch makes refinerycms-settings use rails 4 strong parameters.
