### PR TITLE
Update version to 2.1.2 for refinery form generator

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,8 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'refinerycms', '~> 2.1.1'
-gem 'refinerycms-testing', '~> 2.1.1', :group => :test
+gem 'refinerycms', '~> 2.1.2'
+gem 'refinerycms-testing', '~> 2.1.2', :group => :test
 gem 'refinerycms-acts-as-indexed', '~> 1.0.0'
 
 # Database Configuration

--- a/refinerycms-settings.gemspec
+++ b/refinerycms-settings.gemspec
@@ -3,7 +3,7 @@
 Gem::Specification.new do |s|
   s.platform          = Gem::Platform::RUBY
   s.name              = %q{refinerycms-settings}
-  s.version           = %q{2.1.1}
+  s.version           = %q{2.1.2}
   s.summary           = %q{Settings engine for Refinery CMS}
   s.description       = %q{Adds programmer creatable, user editable settings.}
   s.email             = %q{info@refinerycms.com}
@@ -16,5 +16,5 @@ Gem::Specification.new do |s|
   s.files             = `git ls-files`.split("\n")
   s.test_files        = `git ls-files -- spec/*`.split("\n")
 
-  s.add_dependency 'refinerycms-core', '~> 2.1.1'
+  s.add_dependency 'refinerycms-core', '~> 2.1.2'
 end


### PR DESCRIPTION
Tried to generate a form with refinerycms 2.1.2, it wouldn't bundle because versions were out of date! Fixed.
