### PR TITLE
Update refinerycms-settings.gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ group :assets do
 end
 
 group :development do
-  gem 'quiet_assets'
+  gem 'quiet_assets', '~> 1.1.1'
 end
 
 group :test do

--- a/refinerycms-settings.gemspec
+++ b/refinerycms-settings.gemspec
@@ -15,6 +15,6 @@ Gem::Specification.new do |s|
   s.files             = `git ls-files`.split("\n")
   s.test_files        = `git ls-files -- spec/*`.split("\n")
 
-  s.add_dependency    'refinerycms-core',     ['~> 3.0', '>= 3.0.0']
+  s.add_dependency    'refinerycms-core',     ['~> 4.0', '>= 4.0.0']
   s.add_dependency    'friendly_id',          ['~> 5.0', '>= 5.0.1']
 end

--- a/refinerycms-settings.gemspec
+++ b/refinerycms-settings.gemspec
@@ -15,6 +15,6 @@ Gem::Specification.new do |s|
   s.files             = `git ls-files`.split("\n")
   s.test_files        = `git ls-files -- spec/*`.split("\n")
 
-  s.add_dependency    'refinerycms-core',     ['~> 4.0', '>= 3.0.0']
+  s.add_dependency    'refinerycms-core',     ['>= 3.0.0']
   s.add_dependency    'friendly_id',          ['~> 5.0', '>= 5.0.1']
 end

--- a/refinerycms-settings.gemspec
+++ b/refinerycms-settings.gemspec
@@ -15,6 +15,6 @@ Gem::Specification.new do |s|
   s.files             = `git ls-files`.split("\n")
   s.test_files        = `git ls-files -- spec/*`.split("\n")
 
-  s.add_dependency    'refinerycms-core',     ['~> 4.0', '>= 4.0.0']
+  s.add_dependency    'refinerycms-core',     ['~> 4.0', '>= 3.0.0']
   s.add_dependency    'friendly_id',          ['~> 5.0', '>= 5.0.1']
 end


### PR DESCRIPTION
New refinerycms have been released. 
This PR makes it possible to use refinerycms-settings with the latest refinery.